### PR TITLE
[DSW-585] Run feedback sync in backend's Docker

### DIFF
--- a/engine-wizard/Dockerfile
+++ b/engine-wizard/Dockerfile
@@ -6,23 +6,18 @@ HEALTHCHECK --interval=5m --timeout=10s \
   CMD curl -f http://localhost:3000/ || exit 1
 
 # Install necessary libraries
-RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates netbase wget gdebi-core curl
+RUN apt-get update && apt-get -qq -y install libmemcached-dev ca-certificates netbase wget gdebi-core curl cron
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && gdebi -n wkhtmltox_0.12.5-1.trusty_amd64.deb
 RUN wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-1-amd64.deb && gdebi -n pandoc-2.7.2-1-amd64.deb
 
-# Add built exectutable binary
-ADD engine-wizard-bin /application/engine-wizard-bin
-
-# Create folder for configs & customization
-RUN mkdir /application/engine-wizard
+# Add built exectutable binary and run script
+ADD engine-wizard-bin ./scripts/docker-run.sh /application/
 
 # Add templates
 ADD templates /application/engine-wizard/templates
 
 # Add configs
-ADD config/application.yml /application/engine-wizard/config/application.yml
-ADD config/integration.yml /application/engine-wizard/config/integration.yml
-ADD config/build-info.yml /application/engine-wizard/config/build-info.yml
-ADD config/localization.json /application/engine-wizard/config/localization.json
+ADD config/application.yml config/integration.yml config/build-info.yml config/localization.json /application/engine-wizard/config/
 
-CMD ["./engine-wizard-bin"]
+# Run the run script (preparations and engine-wizard-bin)
+CMD ["bash", "./docker-run.sh"]

--- a/engine-wizard/scripts/docker-run.sh
+++ b/engine-wizard/scripts/docker-run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# This file is supposed to be used in Docker, it is used to prepare 
+# various optional stuff such as cron tasks, starts cron service, 
+# and then runs engine-wizard (backend)
+
+# CRON - scheduled jobs
+if [[ $ENABLE_CRON == "1" ]]; then
+    # Prepare cron dir
+    mkdir -p /etc/cron.d/
+
+    # Set cron for feedback sync if requested
+    if [[ $ENABLE_CRON_FEEDBACK_SYNC == "1" ]]; then
+        if [[ -z $SERVICE_TOKEN || -z $API_URL ]]; then
+            echo "Failed to set Feedback sync cron job: SERVICE_TOKEN and API_URL are required"
+        else
+            echo "0 2 * * *   root   wget --header \"Authorization: Bearer $SERVICE_TOKEN\" \"$API_URL/feedbacks/synchronization\"" > /etc/cron.d/feedback-sync
+        fi
+    fi
+
+    # Prepare cron jobs (under root's crontab)
+    chmod 644 /etc/cron.d/* 2> /dev/null
+    crontab /etc/cron.d/* 2> /dev/null
+    touch /var/log/cron.log /etc/crontab /etc/cron.*/* 2> /dev/null
+
+    # Start cron daemon
+    cron
+fi
+
+# Start engine-wizard
+/application/engine-wizard-bin


### PR DESCRIPTION
This PR:
- Refactors current Dockerfile (removes unnecessary `mkdir` and merges `ADD` of config files)
- Adds `cron` for running jobs as `apt` dependency
- Introduces simple `docker-run.sh` script for preparing the stuff and running the Wizard engine
- Adds option to run cron daemon and to add feedback sync job using environment variables

This should provide enough flexibility (custom cron jobs using mounting files into `/etc/cron.d`, turning on/off cron and sync functionality, adding other preparation steps that require running as `CMD` in the future).