### PR TITLE
[DSW-981] Fix move question in questionnaire migration

### DIFF
--- a/engine-shared/src/Shared/Model/Questionnaire/QuestionnaireUtil.hs
+++ b/engine-shared/src/Shared/Model/Questionnaire/QuestionnaireUtil.hs
@@ -1,7 +1,16 @@
 module Shared.Model.Questionnaire.QuestionnaireUtil where
 
 import qualified Data.List as L
+import Data.Maybe (fromJust)
 import qualified Data.UUID as U
+
+import Shared.Util.String (splitOn)
 
 createReplyKey :: [U.UUID] -> String
 createReplyKey = L.intercalate "." . fmap U.toString
+
+readReplyKey :: String -> [U.UUID]
+readReplyKey = fmap (fromJust . U.fromString) . splitOn "."
+
+replyKeyContains :: String -> U.UUID -> Bool
+replyKeyContains replyKey uuid = uuid `elem` readReplyKey replyKey

--- a/engine-wizard/test/Wizard/Specs/Service/Migration/Questionnaire/MoveSanitizatorSpec.hs
+++ b/engine-wizard/test/Wizard/Specs/Service/Migration/Questionnaire/MoveSanitizatorSpec.hs
@@ -135,6 +135,7 @@ sanitizatorSpec =
       it "m_km1_ch1_q1__to_ch2_q3_aNo" $
         -- GIVEN:
        do
+        let eUuid = question1 ^. uuid
         let pPathSuffix = [chapter1 ^. uuid, question1 ^. uuid]
         let tPathSuffix = [chapter2 ^. uuid, question3 ^. uuid, q3_answerNo ^. uuid, question1 ^. uuid]
         let replies = [rQ1, rQ2]
@@ -142,12 +143,13 @@ sanitizatorSpec =
         let expRQ1 = (createReplyKey tPathSuffix, snd rQ1)
         let expected = [expRQ1, rQ2]
         -- WHEN:
-        let result = computeDesiredPath pPathSuffix tPathSuffix replies
+        let result = computeDesiredPath eUuid pPathSuffix tPathSuffix replies
         -- THEN:
         result `shouldBe` expected
       it "m_km1_ch2_q4_it1_q5__to_ch2_q4_it1_q6_aNo" $
         -- GIVEN:
        do
+        let eUuid = q4_it1_question5 ^. uuid
         let pPathSuffix = [q4_it1_question5 ^. uuid]
         let tPathSuffix = [q4_it1_question6 ^. uuid, q4_it1_q6_answerNo ^. uuid, q4_it1_question5 ^. uuid]
         let replies =
@@ -182,7 +184,7 @@ sanitizatorSpec =
               , rQ4_it2_q6
               ]
         -- WHEN:
-        let result = computeDesiredPath pPathSuffix tPathSuffix replies
+        let result = computeDesiredPath eUuid pPathSuffix tPathSuffix replies
         -- THEN:
         result `shouldBe` expected
     describe "deleteUnwantedReplies" $


### PR DESCRIPTION
The problem was that even un-related replies were destroyed by adding some suffix by this:

https://github.com/ds-wizard/engine-backend/blob/a02f0a0b15b76869b28cd50318cc3e54c621818f/engine-wizard/src/Wizard/Service/Migration/Questionnaire/Migrator/MoveSanitizator.hs#L134

(There was no check whether the reply is actually relevant for that move of a question.)

Now it wraps this function so it is always first check whether the reply is relevant to the move of a question (i.e. UUID of entity is in the path of the reply that is processed), otherwise it is kept unchanged:

https://github.com/ds-wizard/engine-backend/blob/a02f0a0b15b76869b28cd50318cc3e54c621818f/engine-wizard/src/Wizard/Service/Migration/Questionnaire/Migrator/MoveSanitizator.hs#L130-L135