### PR TITLE
Update env (Ubuntu 20.04, Stack 2.5.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   btp:
     name: Build-Tag-Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         component: [registry, wizard]
-        stack: [2.3.1]
+        stack: [2.5.1]
     
     env:
       COMPONENT: ${{ matrix.component }}

--- a/engine-registry/Dockerfile
+++ b/engine-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR /application
 

--- a/engine-wizard/Dockerfile
+++ b/engine-wizard/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR /application
 


### PR DESCRIPTION
There are some [bugfixes in in Stack 2.5.1](https://github.com/commercialhaskell/stack/releases/tag/v2.5.1) and Ubuntu 20.04 is widely adopted (will be used as "ubuntu-latest" on GitHub Actions soon).

Should we also update LTS Haskell (our 15.10, current 16.26 with [GHC 8.8.4](https://www.haskell.org/ghc/blog/20200715-ghc-8.8.4-released.html))?